### PR TITLE
Add stochastic practicals

### DIFF
--- a/apps/stochasticity-1.config.json
+++ b/apps/stochasticity-1.config.json
@@ -1,6 +1,7 @@
 {
     "appType": "stochastic",
     "title": "Stochasticity: Growth",
+    "readOnlyCode": true,
     "help": {
         "tabName": "Explanation"
     }

--- a/apps/stochasticity-1.config.json
+++ b/apps/stochasticity-1.config.json
@@ -1,0 +1,7 @@
+{
+    "appType": "stochastic",
+    "title": "Stochasticity: Growth",
+    "help": {
+        "tabName": "Explanation"
+    }
+}

--- a/apps/stochasticity-2.config.json
+++ b/apps/stochasticity-2.config.json
@@ -1,6 +1,7 @@
 {
     "appType": "stochastic",
     "title": "Stochasticity: Growth and death",
+    "readOnlyCode": true,
     "help": {
         "tabName": "Explanation"
     }

--- a/apps/stochasticity-2.config.json
+++ b/apps/stochasticity-2.config.json
@@ -1,0 +1,7 @@
+{
+    "appType": "stochastic",
+    "title": "Stochasticity: Growth and death",
+    "help": {
+        "tabName": "Explanation"
+    }
+}

--- a/apps/stochasticity-3.config.json
+++ b/apps/stochasticity-3.config.json
@@ -1,0 +1,7 @@
+{
+    "appType": "stochastic",
+    "title": "Stochasticity: SIS",
+    "help": {
+        "tabName": "Explanation"
+    }
+}

--- a/apps/stochasticity-3.config.json
+++ b/apps/stochasticity-3.config.json
@@ -1,6 +1,7 @@
 {
     "appType": "stochastic",
     "title": "Stochasticity: SIS",
+    "readOnlyCode": true,
     "help": {
         "tabName": "Explanation"
     }

--- a/apps/stochasticity-4.config.json
+++ b/apps/stochasticity-4.config.json
@@ -1,6 +1,7 @@
 {
     "appType": "stochastic",
     "title": "Stochasticity: SIR",
+    "readOnlyCode": true,
     "help": {
         "tabName": "Explanation"
     }

--- a/apps/stochasticity-4.config.json
+++ b/apps/stochasticity-4.config.json
@@ -1,0 +1,7 @@
+{
+    "appType": "stochastic",
+    "title": "Stochasticity: SIR",
+    "help": {
+        "tabName": "Explanation"
+    }
+}

--- a/defaultCode/stochasticity-1.R
+++ b/defaultCode/stochasticity-1.R
@@ -1,0 +1,16 @@
+r <- user(0.1)    # Growth rate
+N_init <- user(1) # Initial population size
+
+dt <- 0.01
+time <- step * dt
+
+# Deterministic solution
+initial(N_det) <- N_init
+update(N_det) <- N_init * exp(r * time)
+
+# Stochastic solution
+initial(N_stoch) <- N_init
+
+n_birth <- rbinom(N_stoch, r * dt)
+
+update(N_stoch) <- N_stoch + n_birth

--- a/defaultCode/stochasticity-2.R
+++ b/defaultCode/stochasticity-2.R
@@ -1,0 +1,28 @@
+r <- user(0.1)    # Growth rate
+s <- user(0.06)   # Death rate
+N_init <- user(1) # Initial population size
+
+dt <- 0.01
+time <- step * dt
+
+# Deterministic solution - often unobtainable for non-linear models
+initial(N_det) <- N_init
+update(N_det) <- N_init * exp((r - s) * time)
+
+# Stochastic solution with initial condition, number of births in time
+# t to t + dt and then update to next step
+
+initial(N) <- N_init
+
+# How many events happen in total (births and deaths)?
+growthAndDeath <- rbinom(N, (r + s) * dt)
+
+# How many of these events were deaths?
+death <- rbinom(growthAndDeath, s / (r + s))
+growth <- growthAndDeath - death
+
+update(N) <- N + growth - death
+
+# Track if the population has gone extinct:
+initial(extinct) <- N == 0
+update(extinct) <- N == 0

--- a/defaultCode/stochasticity-3.R
+++ b/defaultCode/stochasticity-3.R
@@ -1,0 +1,36 @@
+beta <- user(0.5)  # Contact rate
+sigma <- user(0.3) # Recovery rate
+N <- user(1000)    # Total population size
+
+initialise_at_steady_state <- user(1)
+
+I_init <- user(1)
+
+## Steady-state prevelance
+I_star <- if (beta > sigma) N * (beta - sigma) / beta else 0
+
+dt <- 0.01
+time <- step * dt
+
+## Stochastic solution
+initial(I) <- if (initialise_at_steady_state > 0) round(I_star) else I_init
+
+FOI <- beta * I / N
+
+# Susceptible population can be derived from the difference between
+# constant total population and the number of infected individuals
+initial(S) <- N - I
+update(S) <- N - I
+
+n_infections <- rbinom(S, FOI * dt)
+n_recoveries <- rbinom(I, sigma * dt)
+
+update(I) <- I + n_infections - n_recoveries
+
+## Deterministic solution
+initial(I_det) <- I
+update(I_det) <- if (initialise_at_steady_state) I_star else
+  (I_star / (1 + (I_star / I_init - 1) * exp(-(beta - sigma) * time)))
+
+initial(extinct) <- I == 0
+update(extinct) <- I == 0

--- a/defaultCode/stochasticity-3.R
+++ b/defaultCode/stochasticity-3.R
@@ -6,13 +6,13 @@ initialise_at_steady_state <- user(1)
 
 I_init <- user(1)
 
-## Steady-state prevelance
+# Steady-state prevelance
 I_star <- if (beta > sigma) N * (beta - sigma) / beta else 0
 
 dt <- 0.01
 time <- step * dt
 
-## Stochastic solution
+# Stochastic solution
 initial(I) <- if (initialise_at_steady_state > 0) round(I_star) else I_init
 
 FOI <- beta * I / N
@@ -27,7 +27,7 @@ n_recoveries <- rbinom(I, sigma * dt)
 
 update(I) <- I + n_infections - n_recoveries
 
-## Deterministic solution
+# Deterministic solution
 initial(I_det) <- I
 update(I_det) <- if (initialise_at_steady_state) I_star else
   (I_star / (1 + (I_star / I_init - 1) * exp(-(beta - sigma) * time)))

--- a/defaultCode/stochasticity-4.R
+++ b/defaultCode/stochasticity-4.R
@@ -1,5 +1,5 @@
 beta <- user(0.5)      # Contact rate
-sigma <- user(0.3      # Recovery rate
+sigma <- user(0.3)     # Recovery rate
 mu <- user(0.001)      # Death rate
 prop_immune <- user(0) # Proportion of population initially immune
 N <- user(10000)       # Total population.

--- a/defaultCode/stochasticity-4.R
+++ b/defaultCode/stochasticity-4.R
@@ -1,0 +1,52 @@
+beta <- user(0.5)      # Contact rate
+sigma <- user(0.3      # Recovery rate
+mu <- user(0.001)      # Death rate
+prop_immune <- user(0) # Proportion of population initially immune
+N <- user(10000)       # Total population.
+I_init <- user(5)      # Initial infecteds
+
+# Derive initial susceptibles from this:
+S_init <- (N - I_init) * (1 - prop_immune)
+
+initialise_at_steady_state <- user(0)
+
+dt <- 0.01
+
+# Steady-state prevelance
+R0 <- beta / (sigma + mu)
+# Number of infecteds at endemic equilibrium state
+I_star <- N * mu * (beta - sigma - mu) / (beta * (mu + sigma))
+# Number of susceptibles at endemic equilibrium state
+S_star <- N / R0
+
+# Stochastic solution
+initial(S) <- if (initialise_at_steady_state > 0) round(S_star) else S_init
+initial(I) <- if (initialise_at_steady_state > 0) round(I_star) else I_init
+initial(R) <- if (initialise_at_steady_state > 0) N - round(I_star) - round(S_star) else N - I_init - S_init
+
+FOI <- beta * I / N
+
+# Two types of events for S, so competing hazards.
+n_events_S <- rbinom(S, (FOI + mu) * dt)
+# A fraction of S events are deaths...
+n_deaths_S <- rbinom(n_events_S, mu/(FOI + mu))
+# ...and the rest are infections.
+n_infections_S <- n_events_S - n_deaths_S
+
+# Two types of events for I, so competing hazards.
+n_events_I <- rbinom(I, (sigma + mu) * dt)
+# A fraction of I events are deaths...
+n_deaths_I <- rbinom(n_events_I, mu / (mu + sigma))
+# ...the rest are recoveries.
+n_recoveries_I <- n_events_I - n_deaths_I
+
+n_deaths_R <- rbinom(R, mu * dt)
+n_births <- n_deaths_S + n_deaths_I + n_deaths_R
+
+# update for next time step
+update(S) <- S - n_deaths_S - n_infections_S + n_births
+update(I) <- I + n_infections_S - n_recoveries_I - n_deaths_I
+update(R) <- R + n_recoveries_I - n_deaths_R
+
+initial(extinct) <- I == 0
+update(extinct) <- I == 0

--- a/help/stochasticity-1.md
+++ b/help/stochasticity-1.md
@@ -10,6 +10,6 @@ $$ N(t) = N(0) e^{rt}$$
 
 where $N(0)$ is the initial population at time $t = 0$.
 
-For a stochastic simulation, the probability that an individual gives birth in a short time, $dt$, is given by $r dt $. The same probability applies to each of the $ N $ individuals. Hence the number of new births will be binomially distributed:
+For a stochastic simulation, the probability that an individual gives birth in a short time, $dt$, is given by $r dt$. The same probability applies to each of the $N$ individuals. Hence the number of new births will be binomially distributed:
 
 $$ \mbox{births in time } dt \sim \mathrm{Binomial}(N, rdt) $$

--- a/help/stochasticity-1.md
+++ b/help/stochasticity-1.md
@@ -1,15 +1,15 @@
 ## Example 1: Deterministic and stochastic growth model
 
-This is a simple simulation of a birth process. Each individual has a birth rate (births per unit time), \(r\). In a short time, \(dt\), we would expect \(r \times dt\) new births for each individual. Thus, in a population of size \(N\) there will be \(rNdt\) births. So the ODE equation for change in population size is
+This is a simple simulation of a birth process. Each individual has a birth rate (births per unit time), $r$. In a short time, $dt$, we would expect $r \times dt$ new births for each individual. Thus, in a population of size $N$ there will be $rNdt$ births. So the ODE equation for change in population size is
 
 $$ \frac{dN}{dt}  = rN $$
 
-where \(r\) is the growth rate per individual per unit time. The solution of this equation is exponential growth i.e.
+where $r$ is the growth rate per individual per unit time. The solution of this equation is exponential growth i.e.
 
 $$ N(t) = N(0) e^{rt}$$
 
-where \(N(0)\) is the initial population at time \(t = 0\).
+where $N(0)$ is the initial population at time $t = 0$.
 
-For a stochastic simulation, the probability that an individual gives birth in a short time, \(dt\), is given by \(r dt \). The same probability applies to each of the \( N \) individuals. Hence the number of new births will be binomially distributed:
+For a stochastic simulation, the probability that an individual gives birth in a short time, $dt$, is given by $r dt $. The same probability applies to each of the $ N $ individuals. Hence the number of new births will be binomially distributed:
 
 $$ \mbox{births in time } dt \sim \mathrm{Binomial}(N, rdt) $$

--- a/help/stochasticity-1.md
+++ b/help/stochasticity-1.md
@@ -1,0 +1,15 @@
+## Example 1: Deterministic and stochastic growth model
+
+This is a simple simulation of a birth process. Each individual has a birth rate (births per unit time), \(r\). In a short time, \(dt\), we would expect \(r \times dt\) new births for each individual. Thus, in a population of size \(N\) there will be \(rNdt\) births. So the ODE equation for change in population size is
+
+$$ \frac{dN}{dt}  = rN $$
+
+where \(r\) is the growth rate per individual per unit time. The solution of this equation is exponential growth i.e.
+
+$$ N(t) = N(0) e^{rt}$$
+
+where \(N(0)\) is the initial population at time \(t = 0\).
+
+For a stochastic simulation, the probability that an individual gives birth in a short time, \(dt\), is given by \(r dt \). The same probability applies to each of the \( N \) individuals. Hence the number of new births will be binomially distributed:
+
+$$ \mbox{births in time } dt \sim \mathrm{Binomial}(N, rdt) $$

--- a/help/stochasticity-2.md
+++ b/help/stochasticity-2.md
@@ -1,0 +1,19 @@
+## Example 2: Stochastic growth and death model
+
+This model includes births and deaths at per-capita rates \(r\) and \(s\) per week, respectively. The ODE for \(N\) is made up of the difference between the mean growth rate and the mean death rate:
+
+$$ \frac{dN}{dt}=rN-sN $$
+
+The difference \((r-s)\) is the net growth rate and the solution is either exponential growth or decline i.e.,
+
+$$ N(t) =N(0) \exp((r-s)t) $$
+
+If births exceed deaths (\(r > s\)) the population grows. If deaths exceed births (\(s > r\)) the population shrinks.
+
+In the stochastic simulation, we have to be more careful as we are dealing with individuals. Each individual has a probability of reproducing and of dying in some short interval, \(dt\). However, it can’t die and then give birth! These two dependent events that can happen are known as competing hazards. To calculate the number of births and deaths in a short time, we first calculate the number of births or deaths:
+
+$$ \mbox{Births or deaths in }dt, n \sim \mathrm{Binomial}(N,(r + s)dt) $$
+
+We then decide which were births and which deaths:
+
+$$ \mbox{Deaths in }dt \sim \mathrm{Binomial}(s / (r + s),n) $$

--- a/help/stochasticity-2.md
+++ b/help/stochasticity-2.md
@@ -1,16 +1,16 @@
 ## Example 2: Stochastic growth and death model
 
-This model includes births and deaths at per-capita rates \(r\) and \(s\) per week, respectively. The ODE for \(N\) is made up of the difference between the mean growth rate and the mean death rate:
+This model includes births and deaths at per-capita rates $r$ and $s$ per week, respectively. The ODE for $N$ is made up of the difference between the mean growth rate and the mean death rate:
 
 $$ \frac{dN}{dt}=rN-sN $$
 
-The difference \((r-s)\) is the net growth rate and the solution is either exponential growth or decline i.e.,
+The difference $(r-s)$ is the net growth rate and the solution is either exponential growth or decline i.e.,
 
 $$ N(t) =N(0) \exp((r-s)t) $$
 
-If births exceed deaths (\(r > s\)) the population grows. If deaths exceed births (\(s > r\)) the population shrinks.
+If births exceed deaths ($r > s$) the population grows. If deaths exceed births ($s > r$) the population shrinks.
 
-In the stochastic simulation, we have to be more careful as we are dealing with individuals. Each individual has a probability of reproducing and of dying in some short interval, \(dt\). However, it can’t die and then give birth! These two dependent events that can happen are known as competing hazards. To calculate the number of births and deaths in a short time, we first calculate the number of births or deaths:
+In the stochastic simulation, we have to be more careful as we are dealing with individuals. Each individual has a probability of reproducing and of dying in some short interval, $dt$. However, it can’t die and then give birth! These two dependent events that can happen are known as competing hazards. To calculate the number of births and deaths in a short time, we first calculate the number of births or deaths:
 
 $$ \mbox{Births or deaths in }dt, n \sim \mathrm{Binomial}(N,(r + s)dt) $$
 

--- a/help/stochasticity-3.md
+++ b/help/stochasticity-3.md
@@ -1,0 +1,23 @@
+## Example 3: Stochastic SIS model
+
+In the next example we consider a model of infection transmission within a closed popluation (no births or deaths): the susceptible-infected-susceptible (SIS) model.
+
+In this model we consider two types of event:
+
+* Infection events, which occur in each time step with probability $((\beta  I dt)/N\)$ per susceptible individual, and
+* Recovery events, which occur in each time step with a probability $(\sigma  dt\)$ per infected individual.
+
+The ODE representation of the model is:
+
+$$\frac{dS}{dt}=-\beta \frac{SI}{N}+\sigma I$$
+$$\frac{dI}{dt}=\beta \frac{SI}{N}-\sigma I$$
+
+The analytical solution to this ODE can be shown to be:
+
+$$I(t)=I^* \frac{1}{1+(I^*/I_0 - 1)\exp(-(\beta -\sigma )t)}$$
+
+where $I_0$ is the initial number of infected individuals and $I^*=N(1-\sigma / \beta )$. After sufficient time, the infection and recovery processes balance each other out. This occurs when the number of infectious individuals reaches its equilibrium value $I^*$. We can write the equilibrium value as
+
+$$I^*= N \left(1-\frac{1}{R_0} \right)$$
+
+since $R_0$ is defined as $\beta /\sigma$. At this point, we say that the disease is endemic in the population.

--- a/help/stochasticity-3.md
+++ b/help/stochasticity-3.md
@@ -4,8 +4,8 @@ In the next example we consider a model of infection transmission within a close
 
 In this model we consider two types of event:
 
-* Infection events, which occur in each time step with probability $((\beta  I dt)/N\)$ per susceptible individual, and
-* Recovery events, which occur in each time step with a probability $(\sigma  dt\)$ per infected individual.
+* Infection events, which occur in each time step with probability $(\beta I dt)/N$ per susceptible individual, and
+* Recovery events, which occur in each time step with a probability $\sigma  dt$ per infected individual.
 
 The ODE representation of the model is:
 

--- a/help/stochasticity-4.md
+++ b/help/stochasticity-4.md
@@ -7,7 +7,7 @@ Compared to the SIS model, the SIR model has one extra compartment, $R$, represe
 The possible events for the SIR system are therefore:
 
 * Infection (S $\rightarrow$ I) at rate  $\beta I / N$
-* Recovery (I $\rightarrow$ S)  at rate  $sigma$
+* Recovery (I $\rightarrow$ S)  at rate  \$sigma$
 * Death of susceptible (S $\rightarrow$ ) at rate $\mu$
 * Death of infected (I $\rightarrow$ ) at rate $\mu$
 * Death of recovered (R $\rightarrow$ ) at rate $\mu$
@@ -15,7 +15,7 @@ The possible events for the SIR system are therefore:
 
 Note that there are two competing hazards for $S$ (death and infection) and for $I$ (death and recovery). For this system,
 
-$$ R_0  = \frac{\beta} {\mu + sigma} $$
+$$ R_0  = \frac{\beta} {\mu + \sigma} $$
 
 and the new equilibria are:
 

--- a/help/stochasticity-4.md
+++ b/help/stochasticity-4.md
@@ -7,7 +7,7 @@ Compared to the SIS model, the SIR model has one extra compartment, $R$, represe
 The possible events for the SIR system are therefore:
 
 * Infection (S $\rightarrow$ I) at rate  $\beta I / N$
-* Recovery (I $\rightarrow$ S)  at rate  \$sigma$
+* Recovery (I $\rightarrow$ S)  at rate  $\sigma$
 * Death of susceptible (S $\rightarrow$ ) at rate $\mu$
 * Death of infected (I $\rightarrow$ ) at rate $\mu$
 * Death of recovered (R $\rightarrow$ ) at rate $\mu$

--- a/help/stochasticity-4.md
+++ b/help/stochasticity-4.md
@@ -1,0 +1,23 @@
+## Example 4: Stochastic SIR model
+
+This model investigates the behaviour of a Susceptible-Infected-Recovered (SIR) model. The code to do this in `odin` can be easily adapted from the SIS code.
+
+Compared to the SIS model, the SIR model has one extra compartment, \( R \), representing recovered, immune individuals and four extra events: death of susceptible, infected and recovered individuals at rate \( \mu \), and birth of new susceptibles at rate \( B \). To simplify, in any time period, we can make the number of births equal to the sum of the number of deaths. This keeps the total population constant.
+
+The possible events for the SIR system are therefore:
+
+* Infection (S \( \rightarrow \) I) at rate  \( \beta I / N \)
+* Recovery (I \( \rightarrow \) S)  at rate  \( sigma \)
+* Death of susceptible (S \( \rightarrow \) ) at rate \( \mu \)
+* Death of infected (I \( \rightarrow \) ) at rate \( \mu \)
+* Death of recovered (R \( \rightarrow \) ) at rate \( \mu \)
+* Births ( \( \rightarrow \) S) at rate \( B = \mu N \)
+
+Note that there are two competing hazards for \( S \) (death and infection) and for \( I \) (death and recovery). For this system,
+
+$$ R_0  = \frac{\beta} { (\mu + sigma) } $$
+
+and the new equilibria are:
+
+$$ S^* = \frac{1} {R_0} $$
+$$ I^* = \frac{N \mu} {\beta}  (R_0-1) $$

--- a/help/stochasticity-4.md
+++ b/help/stochasticity-4.md
@@ -2,20 +2,20 @@
 
 This model investigates the behaviour of a Susceptible-Infected-Recovered (SIR) model. The code to do this in `odin` can be easily adapted from the SIS code.
 
-Compared to the SIS model, the SIR model has one extra compartment, \( R \), representing recovered, immune individuals and four extra events: death of susceptible, infected and recovered individuals at rate \( \mu \), and birth of new susceptibles at rate \( B \). To simplify, in any time period, we can make the number of births equal to the sum of the number of deaths. This keeps the total population constant.
+Compared to the SIS model, the SIR model has one extra compartment, $R$, representing recovered, immune individuals and four extra events: death of susceptible, infected and recovered individuals at rate $\mu$, and birth of new susceptibles at rate $B$. To simplify, in any time period, we can make the number of births equal to the sum of the number of deaths. This keeps the total population constant.
 
 The possible events for the SIR system are therefore:
 
-* Infection (S \( \rightarrow \) I) at rate  \( \beta I / N \)
-* Recovery (I \( \rightarrow \) S)  at rate  \( sigma \)
-* Death of susceptible (S \( \rightarrow \) ) at rate \( \mu \)
-* Death of infected (I \( \rightarrow \) ) at rate \( \mu \)
-* Death of recovered (R \( \rightarrow \) ) at rate \( \mu \)
-* Births ( \( \rightarrow \) S) at rate \( B = \mu N \)
+* Infection (S $\rightarrow$ I) at rate  $\beta I / N$
+* Recovery (I $\rightarrow$ S)  at rate  $sigma$
+* Death of susceptible (S $\rightarrow$ ) at rate $\mu$
+* Death of infected (I $\rightarrow$ ) at rate $\mu$
+* Death of recovered (R $\rightarrow$ ) at rate $\mu$
+* Births ( $\rightarrow$ S) at rate $B = \mu N$
 
-Note that there are two competing hazards for \( S \) (death and infection) and for \( I \) (death and recovery). For this system,
+Note that there are two competing hazards for $S$ (death and infection) and for $I$ (death and recovery). For this system,
 
-$$ R_0  = \frac{\beta} { (\mu + sigma) } $$
+$$ R_0  = \frac{\beta} {\mu + sigma} $$
 
 and the new equilibria are:
 


### PR DESCRIPTION
This imports the practicals from the shortcourse (2022 and Singapore), but with modification:

* we need to remove use of `output()` as it's not supported in the odin to JavaScript target (see [this vignette](https://mrc-ide.github.io/odin.dust/articles/porting.html#avoiding-output) for details)
* I've updated to follow the changes in nomenclature made by Lilith for the sg course:
  - using `sigma` in place of `nu`
  - avoiding `0` as a suffix meaning initial (`I0` becomes `I_init` to avoid confusion with `R0`)
  - nicer name of `initialise_at_steady_state` to indicate if we use the steady state solution or not
* I think that among all that I've managed to avoid the divide by zero error - it probably won't crash the app but might not do good things. It'd be good if you could check this please.

I've ported all these changes to the md so that they line up, and checked that that LaTeX renders correctly (some was not as `\(...\)` syntax appears not supported with the renderer we are using). I've also gone through and been really pedantic with code formatting because it was annoying me (i.e., comment styling, lining things up, consistent spacing).

Please feel free to make suggestions/changes/etc. Alternatively once this is in you can make a PR into this repo that changes whatever you would like